### PR TITLE
Modify contains comparison to ignore missing keys recursively

### DIFF
--- a/jsoncompare/jsoncompare.py
+++ b/jsoncompare/jsoncompare.py
@@ -49,7 +49,7 @@ def _generate_pprint_json(value):
     return json.dumps(value, sort_keys=True, indent=4)
 
 
-def _is_dict_same(expected, actual, ignore_value_of_keys):
+def _is_dict_same(expected, actual, ignore_value_of_keys, ignore_missing_keys=False):
     # DAN - I had to flip flop this
     for key in expected:
         if not key in actual:
@@ -63,7 +63,7 @@ def _is_dict_same(expected, actual, ignore_value_of_keys):
         if not key in ignore_value_of_keys:
             # have to change order
             #are_same_flag, stack = _are_same(actual[key], expected[key], ignore_value_of_keys)
-            are_same_flag, stack = _are_same(expected[key], actual[key],ignore_value_of_keys)
+            are_same_flag, stack = _are_same(expected[key], actual[key], ignore_value_of_keys, ignore_missing_keys)
             if not are_same_flag:
                 return False, \
                        stack.append(StackItem('Different values', expected[key], actual[key]))
@@ -134,10 +134,8 @@ def _are_same(expected, actual, ignore_value_of_keys, ignore_missing_keys=False)
                                   expected,
                                   actual))
 
-    
-
     if isinstance(expected, dict):
-        return _is_dict_same(expected, actual, ignore_value_of_keys)
+        return _is_dict_same(expected, actual, ignore_value_of_keys, ignore_missing_keys)
 
     if isinstance(expected, list):
         return _is_list_same(expected, actual, ignore_value_of_keys)

--- a/jsoncompare/jsoncompare.py
+++ b/jsoncompare/jsoncompare.py
@@ -69,9 +69,9 @@ def _is_dict_same(expected, actual, ignore_value_of_keys, ignore_missing_keys=Fa
                        stack.append(StackItem('Different values', expected[key], actual[key]))
     return True, Stack()
 
-def _is_list_same(expected, actual, ignore_value_of_keys):
+def _is_list_same(expected, actual, ignore_value_of_keys, ignore_missing_keys=False):
     for i in xrange(len(expected)):
-        are_same_flag, stack = _are_same(expected[i], actual[i], ignore_value_of_keys)
+        are_same_flag, stack = _are_same(expected[i], actual[i], ignore_value_of_keys, ignore_missing_keys)
         if not are_same_flag:
             return False, \
                    stack.append(
@@ -138,7 +138,7 @@ def _are_same(expected, actual, ignore_value_of_keys, ignore_missing_keys=False)
         return _is_dict_same(expected, actual, ignore_value_of_keys, ignore_missing_keys)
 
     if isinstance(expected, list):
-        return _is_list_same(expected, actual, ignore_value_of_keys)
+        return _is_list_same(expected, actual, ignore_value_of_keys, ignore_missing_keys)
 
     return False, Stack().append(StackItem('Unhandled Type: {0}'.format(type(expected)), expected, actual))
 

--- a/jsoncompare/test/test_jsoncompare.py
+++ b/jsoncompare/test/test_jsoncompare.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 
 import unittest
-import sys, os
+import os
+import sys
 
 path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if not path in sys.path:
     sys.path.insert(1, path)
 import jsoncompare
+
 
 class TestJSONCompare(unittest.TestCase):
 
@@ -197,7 +199,7 @@ class TestJSONCompare(unittest.TestCase):
             ]
         }
         b = {
-            "failureReason" : "Invalid request entity",
+            "failureReason": "Invalid request entity",
             "fieldValidationErrors" : [
                 {
                     "field" : "Catalog.catalogOwner",
@@ -213,8 +215,8 @@ class TestJSONCompare(unittest.TestCase):
 
     def test_nested_list_order_inner_val_sensitivity_false(self):
         a = {
-            "failureReason" : "Invalid request entity",
-            "fieldValidationErrors" : [
+            "failureReason": "Invalid request entity",
+            "fieldValidationErrors": [
                 {
                     "field" : "Catalog.catalogOwner",
                     "reason" : "may not be smelly"
@@ -226,7 +228,7 @@ class TestJSONCompare(unittest.TestCase):
             ]
         }
         b = {
-            "failureReason" : "Invalid request entity",
+            "failureReason": "Invalid request entity",
             "fieldValidationErrors" : [
                 {
                     "field" : "Catalog.name",
@@ -244,7 +246,6 @@ class TestJSONCompare(unittest.TestCase):
         a = open("testing-data/jsonbloba.json").read()
         b = open("testing-data/jsonblobb.json").read()
         self.assertTrue(jsoncompare.json_are_same(a, b, True)[0])
-
 
     def test_giant_json_finds_reordering(self):
         a = open("testing-data/jsonbloba.json").read()
@@ -304,7 +305,7 @@ class TestJSONCompare(unittest.TestCase):
         self.assertFalse(jsoncompare.contains(expected, actual)[0])
         #same, error_message = jsoncompare.contains(expected, actual)
         #assert same, error_message
-	
+
     # Test two json where Actual is larger - it can (potentialy) contain all of the expected attributes
     def test_contains_actual_bigger(self):
         actual = [
@@ -318,6 +319,23 @@ class TestJSONCompare(unittest.TestCase):
         ]
         self.assertTrue(jsoncompare.contains(expected, actual)[0])
 
+    # Test two json where Actual is larger - it can (potentialy) contain all of the expected attributes
+    def test_contains_actual_bigger_nested(self):
+        actual = {
+            "inner": [
+                {"wtf": "omg"},
+                {"wtf1": "omg1"},
+                {"wtf3": "omg3"}
+            ]
+        }
+        expected = {
+            "inner": [
+                {"wtf": "omg"},
+                {"wtf1": "omg1"}
+            ]
+        }
+        self.assertTrue(jsoncompare.contains(expected, actual)[0])
+
     # Test two json where Actual is smaller - it can NOT contain all of expected attributes
     def test_contains_actual_smaller(self):
         actual = [
@@ -329,6 +347,40 @@ class TestJSONCompare(unittest.TestCase):
             {"wtf1": "omg1"},
             {"wtf2": "omg2"}
         ]
+        self.assertFalse(jsoncompare.contains(expected, actual)[0])
+
+    # Test two json where Actual is smaller - it can NOT contain all of expected attributes
+    def test_contains_actual_smaller_nested(self):
+        actual = {
+            "inner": [
+                {"wtf": "omg"},
+                {"wtf1": "omg1"}
+            ]
+        }
+        expected = {
+            "inner": [
+                {"wtf": "omg"},
+                {"wtf1": "omg1"},
+                {"wtf2": "omg2"}
+            ]
+        }
+        self.assertFalse(jsoncompare.contains(expected, actual)[0])
+
+    # Test two json where Actual is larger - it can (potentialy) contain all of the expected attributes
+    def test_contains_nested_different_value(self):
+        actual = {
+            "inner": [
+                {"wtf": "omg!!!!!!!"},
+                {"wtf1": "omg1"},
+                {"wtf3": "omg3"}
+            ]
+        }
+        expected = {
+            "inner": [
+                {"wtf": "omg"},
+                {"wtf1": "omg1"}
+            ]
+        }
         self.assertFalse(jsoncompare.contains(expected, actual)[0])
 
 

--- a/jsoncompare/test/test_jsoncompare.py
+++ b/jsoncompare/test/test_jsoncompare.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
 import unittest
-import os
-import sys
+import sys, os
 
 path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if not path in sys.path:
     sys.path.insert(1, path)
 import jsoncompare
-
 
 class TestJSONCompare(unittest.TestCase):
 
@@ -199,7 +197,7 @@ class TestJSONCompare(unittest.TestCase):
             ]
         }
         b = {
-            "failureReason": "Invalid request entity",
+            "failureReason" : "Invalid request entity",
             "fieldValidationErrors" : [
                 {
                     "field" : "Catalog.catalogOwner",
@@ -215,8 +213,8 @@ class TestJSONCompare(unittest.TestCase):
 
     def test_nested_list_order_inner_val_sensitivity_false(self):
         a = {
-            "failureReason": "Invalid request entity",
-            "fieldValidationErrors": [
+            "failureReason" : "Invalid request entity",
+            "fieldValidationErrors" : [
                 {
                     "field" : "Catalog.catalogOwner",
                     "reason" : "may not be smelly"
@@ -228,7 +226,7 @@ class TestJSONCompare(unittest.TestCase):
             ]
         }
         b = {
-            "failureReason": "Invalid request entity",
+            "failureReason" : "Invalid request entity",
             "fieldValidationErrors" : [
                 {
                     "field" : "Catalog.name",
@@ -246,6 +244,7 @@ class TestJSONCompare(unittest.TestCase):
         a = open("testing-data/jsonbloba.json").read()
         b = open("testing-data/jsonblobb.json").read()
         self.assertTrue(jsoncompare.json_are_same(a, b, True)[0])
+
 
     def test_giant_json_finds_reordering(self):
         a = open("testing-data/jsonbloba.json").read()
@@ -305,7 +304,7 @@ class TestJSONCompare(unittest.TestCase):
         self.assertFalse(jsoncompare.contains(expected, actual)[0])
         #same, error_message = jsoncompare.contains(expected, actual)
         #assert same, error_message
-
+	
     # Test two json where Actual is larger - it can (potentialy) contain all of the expected attributes
     def test_contains_actual_bigger(self):
         actual = [
@@ -318,6 +317,19 @@ class TestJSONCompare(unittest.TestCase):
             {"wtf1": "omg1"}
         ]
         self.assertTrue(jsoncompare.contains(expected, actual)[0])
+
+    # Test two json where Actual is smaller - it can NOT contain all of expected attributes
+    def test_contains_actual_smaller(self):
+        actual = [
+            {"wtf": "omg"},
+            {"wtf1": "omg1"}
+        ]
+        expected = [
+            {"wtf": "omg"},
+            {"wtf1": "omg1"},
+            {"wtf2": "omg2"}
+        ]
+        self.assertFalse(jsoncompare.contains(expected, actual)[0])
 
     # Test two json where Actual is larger - it can (potentialy) contain all of the expected attributes
     def test_contains_actual_bigger_nested(self):
@@ -335,19 +347,6 @@ class TestJSONCompare(unittest.TestCase):
             ]
         }
         self.assertTrue(jsoncompare.contains(expected, actual)[0])
-
-    # Test two json where Actual is smaller - it can NOT contain all of expected attributes
-    def test_contains_actual_smaller(self):
-        actual = [
-            {"wtf": "omg"},
-            {"wtf1": "omg1"}
-        ]
-        expected = [
-            {"wtf": "omg"},
-            {"wtf1": "omg1"},
-            {"wtf2": "omg2"}
-        ]
-        self.assertFalse(jsoncompare.contains(expected, actual)[0])
 
     # Test two json where Actual is smaller - it can NOT contain all of expected attributes
     def test_contains_actual_smaller_nested(self):

--- a/jsoncompare/test/test_jsoncompare.py
+++ b/jsoncompare/test/test_jsoncompare.py
@@ -367,18 +367,101 @@ class TestJSONCompare(unittest.TestCase):
         self.assertFalse(jsoncompare.contains(expected, actual)[0])
 
     # Test two json where Actual is larger - it can (potentialy) contain all of the expected attributes
-    def test_contains_nested_different_value(self):
+    def test_contains_nested_in_array(self):
         actual = {
             "inner": [
-                {"wtf": "omg!!!!!!!"},
-                {"wtf1": "omg1"},
-                {"wtf3": "omg3"}
+                {"a": 1, "b": 2}
             ]
         }
         expected = {
             "inner": [
-                {"wtf": "omg"},
-                {"wtf1": "omg1"}
+                {"a": 1}
+            ]
+        }
+        self.assertTrue(jsoncompare.contains(expected, actual)[0])
+
+    # Test two json where Actual is larger - it can (potentialy) contain all of the expected attributes
+    def test_contains_nested_in_array_in_object(self):
+        actual = {
+            "outer": [
+                {"inner": {"a": 1, "b": 2}}
+            ]
+        }
+        expected = {
+            "outer": [
+                {"inner": {"a": 1}}
+            ]
+        }
+        self.assertTrue(jsoncompare.contains(expected, actual)[0])
+
+    # Test two json where Actual is larger - it can (potentialy) contain all of the expected attributes
+    def test_contains_nested_in_array_in_object_in_array(self):
+        actual = {
+            "outer": [
+                {
+                    "inner": [
+                        {"a": 1, "b": 2}
+                    ]
+                }
+            ]
+        }
+        expected = {
+            "outer": [
+                {
+                    "inner": [
+                        {"b": 2}
+                    ]
+                }
+            ]
+        }
+        self.assertTrue(jsoncompare.contains(expected, actual)[0])
+
+    # Test two json where Actual is larger - it can (potentialy) contain all of the expected attributes
+    def test_not_contains_nested_in_array(self):
+        actual = {
+            "inner": [
+                {"a": 1}
+            ]
+        }
+        expected = {
+            "inner": [
+                {"a": 1, "b": 2}
+            ]
+        }
+        self.assertFalse(jsoncompare.contains(expected, actual)[0])
+
+    # Test two json where Actual is larger - it can (potentialy) contain all of the expected attributes
+    def test_not_contains_nested_in_array_in_object(self):
+        actual = {
+            "outer": [
+                {"inner": {"a": 1}}
+            ]
+        }
+        expected = {
+            "outer": [
+                {"inner": {"a": 1, "b": 2}}
+            ]
+        }
+        self.assertFalse(jsoncompare.contains(expected, actual)[0])
+
+    # Test two json where Actual is larger - it can (potentialy) contain all of the expected attributes
+    def test_not_contains_nested_in_array_in_object_in_array(self):
+        actual = {
+            "outer": [
+                {
+                    "inner": [
+                        {"b": 2}
+                    ]
+                }
+            ]
+        }
+        expected = {
+            "outer": [
+                {
+                    "inner": [
+                        {"a": 1, "b": 2}
+                    ]
+                }
             ]
         }
         self.assertFalse(jsoncompare.contains(expected, actual)[0])


### PR DESCRIPTION
I modified the contains function to ignore missing keys at all levels of the object tree, instead of just the top level. I added tests for all of the odd scenarios I could think of.
